### PR TITLE
Add DateDim Table & Fix Campaign TZ Offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,8 @@ builder.build_database('klaviyo')
 # Optionally but recommended, a separate user can be created with only access to the database
 builder.create_user('klaviyo_user', 'StrongPassword1!')
 
-# Create the table structure
-builder.build_tables('klaviyo')
+# Create the table structure, optionally include a start date in 'yyyy-mm-dd' formart to build a date dimension table
+builder.build_tables('klaviyo', date_start='2021-01-01')
 ```
 
 #### Create Database via Command Line
@@ -160,7 +160,17 @@ builder.build_tables('klaviyo')
 $ build_klaviyo --help
 Usage: build_klaviyo [OPTIONS]
 
-  Build Klaviyo Database.
+   Builds database, tables and user for Klaviyo Data App.
+
+    Add --tables-only to only build tables with existing --db.
+
+    Include --db_user and --db_pass to create a user for the database.
+
+    Include --date-dimension-start date to build a date dimension table.
+    Date format is yyyy-MM-dd.
+
+    Without --db_user and --db_pass, the admin user or existsing --db 
+    user needs to be used to run the app
 
 Options:
   --server TEXT                   Server to connect to
@@ -171,6 +181,7 @@ Options:
   --db TEXT                       SQL Server database
   --tables-only / --db-and-tables
                                   Only build tables
+  --date-dimension-start          Start date for date dimension table
   --help                          Show this message and exit.
 
 # Build klaviyo database and tables

--- a/scripts/klaviyo.sql
+++ b/scripts/klaviyo.sql
@@ -156,5 +156,91 @@ CREATE TABLE $(Schema).CampaignExcludes (
 )
 ON [PRIMARY]
 GO
+DECLARE @StartDate  date = '$(StartDate)';
+
+DECLARE @CutoffDate date = DATEADD(DAY, -1, DATEADD(YEAR, 30, @StartDate));
+
+;WITH seq(n) AS
+(
+  SELECT 0 UNION ALL SELECT n + 1 FROM seq
+  WHERE n < DATEDIFF(DAY, @StartDate, @CutoffDate)
+),
+d(d) AS
+(
+  SELECT DATEADD(DAY, n, @StartDate) FROM seq
+),
+src AS
+(
+  SELECT
+    TheDate         = CONVERT(date, d),
+    TheDay          = DATEPART(DAY,       d),
+    TheDayName      = DATENAME(WEEKDAY,   d),
+    TheWeek         = DATEPART(WEEK,      d),
+    TheISOWeek      = DATEPART(ISO_WEEK,  d),
+    TheDayOfWeek    = DATEPART(WEEKDAY,   d),
+    TheMonth        = DATEPART(MONTH,     d),
+    TheMonthName    = DATENAME(MONTH,     d),
+    TheQuarter      = DATEPART(Quarter,   d),
+    TheYear         = DATEPART(YEAR,      d),
+    TheFirstOfMonth = DATEFROMPARTS(YEAR(d), MONTH(d), 1),
+    TheLastOfYear   = DATEFROMPARTS(YEAR(d), 12, 31),
+    TheDayOfYear    = DATEPART(DAYOFYEAR, d)
+  FROM d
+),
+dim AS
+(
+  SELECT
+    TheDate,
+    TheDay,
+    TheDaySuffix        = CONVERT(char(2), IIF(TheDay / 10 = 1, 'th', CASE RIGHT(TheDay, 1)
+                                                                          WHEN '1' THEN 'st'
+                                                                          WHEN '2' THEN 'nd'
+                                                                          WHEN '3' THEN 'rd'
+                                                                          ELSE 'th' END)),
+    TheDayName,
+    TheDayOfWeek,
+    TheDayOfWeekInMonth = CONVERT(tinyint, ROW_NUMBER() OVER
+                            (PARTITION BY TheFirstOfMonth, TheDayOfWeek ORDER BY TheDate)),
+    TheDayOfYear,
+    IsWeekend           = IIF(TheDayOfWeek IN (CASE @@DATEFIRST WHEN 1 THEN 6 WHEN 7 THEN 1 END, 7), 1, 0),
+    TheWeek,
+    TheISOweek,
+    TheFirstOfWeek      = DATEADD(DAY, 1 - TheDayOfWeek, TheDate),
+    TheLastOfWeek       = DATEADD(DAY, 6, DATEADD(DAY, 1 - TheDayOfWeek, TheDate)),
+    TheWeekOfMonth      = CONVERT(tinyint, DENSE_RANK() OVER
+                            (PARTITION BY TheYear, TheMonth ORDER BY TheWeek)),
+    TheMonth,
+    TheMonthName,
+    TheFirstOfMonth,
+    TheLastOfMonth      = MAX(TheDate) OVER (PARTITION BY TheYear, TheMonth),
+    TheFirstOfNextMonth = DATEADD(MONTH, 1, TheFirstOfMonth),
+    TheLastOfNextMonth  = DATEADD(DAY, -1, DATEADD(MONTH, 2, TheFirstOfMonth)),
+    TheQuarter,
+    TheFirstOfQuarter   = MIN(TheDate) OVER (PARTITION BY TheYear, TheQuarter),
+    TheLastOfQuarter    = MAX(TheDate) OVER (PARTITION BY TheYear, TheQuarter),
+    TheYear,
+    TheISOYear          = TheYear - CASE WHEN TheMonth = 1 AND TheISOWeek > 51 THEN 1
+                            WHEN TheMonth = 12 AND TheISOWeek = 1  THEN -1 ELSE 0 END,
+    TheFirstOfYear      = DATEFROMPARTS(TheYear, 1,  1),
+    TheLastOfYear,
+    IsLeapYear          = CONVERT(bit, IIF((TheYear % 400 = 0)
+                                               OR (TheYear % 4 = 0 AND TheYear % 100 <> 0), 1, 0)),
+    Has53Weeks          = IIF(DATEPART(WEEK, TheLastOfYear) = 53, 1, 0),
+    Has53ISOWeeks       = IIF(DATEPART(ISO_WEEK, TheLastOfYear) = 53, 1, 0),
+    MMYYYY              = CONVERT(char(2), CONVERT(char(8), TheDate, 101))
+                          + CONVERT(char(4), TheYear),
+    Style101            = CONVERT(char(10), TheDate, 101),
+    Style103            = CONVERT(char(10), TheDate, 103),
+    Style112            = CONVERT(char(8),  TheDate, 112),
+    Style120            = CONVERT(char(10), TheDate, 120)
+  FROM src
+)
+SELECT * INTO $(SchemaName).DateDimension FROM dim
+  ORDER BY TheDate
+  OPTION (MAXRECURSION 0);
+GO
+
+CREATE UNIQUE CLUSTERED INDEX PK_DateDimension ON $(SchemaName).DateDimension(TheDate);
+GO
 SET NOEXEC OFF
 GO

--- a/src/klaviyo_data/cli.py
+++ b/src/klaviyo_data/cli.py
@@ -62,14 +62,20 @@ def cli_runner(days, between, config):
               default='klaviyo', help='SQL Server database')
 @click.option('--tables-only/--db-and-tables', default=False,
               help='Only build tables')
+@click.option('--date-dimension-start', type='str',
+              help='Build date table from start date 2022-01-01')
 def klaviyo_db_builder(server, port, sa_user, sa_pass, db_user, db_pass,
                        driver, db, tables_only):
     """\b
     Builds database, tables and user for Klaviyo Data App.
     \b
     Add --tables-only to only build tables with existing --db.
-
+    \b
     Include --db_user and --db_pass to create a user for the database.
+    
+    \b
+    Include --date-dimension-start date to build a date dimension table.
+    Date format is yyyy-MM-dd.
 
     \b
     Without --db_user and --db_pass, the admin user or existsing --db 

--- a/src/klaviyo_data/klaviyo_app.py
+++ b/src/klaviyo_data/klaviyo_app.py
@@ -289,10 +289,13 @@ class KlaviyoData:
         camp_list = id_gen(self.engine, 'CampaignList')
 
         for row in camp_list:
-            if row.sent_at is None or row.sent_at.date() < start_date or \
+            if row.sent_at is None or \
+                    row.sent_at.date() < (start_date - timedelta(days=2)) or \
                     (row.sent_at.date() - end_date).days > 7:
                 continue
-            data = self.metric_data(row.id, row.sent_at, metric_where,
+            data = self.metric_data(row.id,
+                                    (row.sent_at - timedelta(days=2)),
+                                    metric_where,
                                     '$message')
             if len(data.index) == 0:
                 continue

--- a/src/klaviyo_data/sql_app.py
+++ b/src/klaviyo_data/sql_app.py
@@ -1,5 +1,8 @@
 import logging
+import calendar
 from pathlib import Path
+from dateutil import parser
+from datetime import date, timedelta as td
 from configparser import SectionProxy
 from typing import Optional
 from sqlalchemy import create_engine, MetaData, Table, select, Column, inspect
@@ -7,7 +10,8 @@ from sqlalchemy.engine import URL
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.engine import Engine as EngType
 from pandas import DataFrame
-from .vars import merge_str, MergeDict, SQLBuilder, TableBuilder
+from klaviyo_data.vars import (merge_str, MergeDict, SQLBuilder,
+                               TableBuilder, DateDimension)
 
 DEFAULT_DRIVER = 'ODBC Driver 17 for SQL Server'
 
@@ -132,7 +136,8 @@ class DBBuilder:
                 conn.execute(sql_obj.alter_db())
         return True
 
-    def build_tables(self, db_name: Optional[str] = None) -> bool:
+    def build_tables(self, db_name: Optional[str] = None,
+                     date_start: Optional[str] = None) -> bool:
         if self.db_name and db_name is None:
             logger.debug("Please specify db_name")
             return False
@@ -148,15 +153,31 @@ class DBBuilder:
             'driver': self.driver
         }
         kv_engine = get_engine(kv_conf)
+
         with kv_engine.connect().execution_options(
                 isolation_level='AUTOCOMMIT') as conn:
             tbl_class = TableBuilder()
             tbl_class.meta.create_all(bind=conn)
-
+        if date_start is not None:
+            build_date_dimension(kv_engine, date_start)
         tester = inspect(kv_engine)
         if tester.has_table("Metrics"):
             return True
         return False
+
+
+def build_date_dimension(engine: EngType, date_str: str) -> bool:
+    date_rows = date_row_builder(date_str)
+    with engine.connect().execution_options(
+            isolation_level='AUTOCOMMIT') as conn:
+        conn.execute(DateDimension.create_table)
+        conn.execute(DateDimension.create_index)
+    meta = MetaData()
+    tbl_meta = Table("DateDimension", meta, autoload_with=engine)
+    with engine.connect().execution_options(
+            isolation_level='AUTOCOMMIT') as conn:
+        conn.execute(tbl_meta.insert(), date_rows)
+    return True
 
 
 def get_engine(sql_conf):
@@ -239,3 +260,108 @@ def data_qry(engine: EngType,
                               **merge_dict)  # type: ignore
         con.execute(merge_qry)
         con.execute("DROP TABLE IF EXISTS #tmp")
+
+
+def get_week_of_month(cal_date) -> int:
+    """Get the week of the month starting sunday."""
+    cal = calendar.Calendar(6)
+    weeks = cal.monthdayscalendar(cal_date.year, cal_date.month)
+    for x in range(len(weeks)):
+        if cal_date.day in weeks[x]:
+            return x + 1
+    return 0
+
+
+def date_row_builder(start_str) -> list:
+    """Build rows for DateDimension table."""
+    try:
+        start_date = parser.isoparse(start_str).date()
+    except parser.ParserError:
+        logger.debug("Error parsing start date, defaulting to 1/1/2019")
+        start_date = date(2019, 1, 1)
+    end_date = start_date + td(days=(30*365))
+    row_array = []
+    current_date = start_date
+    while (current_date <= end_date):
+        TheDate = current_date
+        TheDay = current_date.day
+        TheDaySuffix = 'tsnrhtdd'[TheDay % 5 * (
+            TheDay % 100 ^ 15 > 4 > TheDay % 10)::4]
+        TheDayName = TheDate.strftime('%A')
+        TheDayOfWeek = int(TheDate.strftime('%w')) + 1
+        TheDayOfWeekInMonth = (TheDay - 1) // 7 + 1
+        TheDayOfYear = current_date.timetuple().tm_yday
+        IsWeekend = 1 if TheDayOfWeek in [1, 7] else 0
+        TheWeek = int(TheDate.strftime('%U')) + 1
+        TheISOWeek = int(TheDate.isocalendar().week)
+        TheFirstOfWeek = TheDate - td(days=TheDate.isoweekday() % 7)
+        TheLastOfWeek = TheFirstOfWeek + td(days=6)
+        TheWeekOfMonth = get_week_of_month(TheDate)
+        TheMonth = int(TheDate.month)
+        TheMonthName = TheDate.strftime('%B')
+        TheFirstOfMonth = TheDate.replace(day=1)
+        TheLastOfMonth = TheDate.replace(day=calendar.monthrange(
+            TheDate.year, TheDate.month)[1])
+        TheFirstOfNextMonth = TheLastOfMonth + td(days=1)
+        TheLastOfNextMonth = TheFirstOfNextMonth.replace(
+            day=calendar.monthrange(TheFirstOfNextMonth.year,
+                                    TheFirstOfNextMonth.month)[1])
+        TheQuarter = (TheMonth - 1) // 3 + 1
+        TheFirstOfQuarter = date(TheDate.year, 3 * (
+            (TheDate.month - 1) // 3) + 1, 1)
+        TheLastOfQuarter = date(
+                TheDate.year + 3 * TheQuarter // 12,
+                3 * TheQuarter % 12 + 1, 1) \
+            + td(days=-1)
+        TheYear = TheDate.year
+        TheISOYear = TheDate.isocalendar().year
+        TheFirstOfYear = TheDate.replace(month=1, day=1)
+        TheLastOfYear = TheDate.replace(month=12, day=31)
+        IsLeapYear = (TheYear % 400 == 0) and (TheYear % 100 == 0)
+        Has53Weeks = TheLastOfYear.strftime('%U') == '53'
+        Has53ISOWeeks = TheLastOfYear.isocalendar().week == 53
+        MMYYYY = TheDate.strftime('%m%Y')
+        Style101 = TheDate.strftime('%m/%d/%Y')
+        Style103 = TheDate.strftime('%d/%m/%Y')
+        Style112 = TheDate.strftime('%Y%m%d')
+        Style120 = TheDate.strftime('%Y-%m-%d')
+        row_array.append(
+            {
+                'TheDate': TheDate,
+                'TheDay': TheDay,
+                'TheDaySuffix': TheDaySuffix,
+                'TheDayName': TheDayName,
+                'TheDayOfWeek': TheDayOfWeek,
+                'TheDayOfWeekInMonth': TheDayOfWeekInMonth,
+                'TheDayOfYear': TheDayOfYear,
+                'IsWeekend': IsWeekend,
+                'TheWeek': TheWeek,
+                'TheISOWeek': TheISOWeek,
+                'TheFirstOfWeek': TheFirstOfWeek,
+                'TheLastOfWeek': TheLastOfWeek,
+                'TheWeekOfMonth': TheWeekOfMonth,
+                'TheMonth': TheMonth,
+                'TheMonthName': TheMonthName,
+                'TheFirstOfMonth': TheFirstOfMonth,
+                'TheLastOfMonth': TheLastOfMonth,
+                'TheFirstOfNextMonth': TheFirstOfNextMonth,
+                'TheLastOfNextMonth': TheLastOfNextMonth,
+                'TheQuarter': TheQuarter,
+                'TheFirstOfQuarter': TheFirstOfQuarter,
+                'TheLastOfQuarter': TheLastOfQuarter,
+                'TheYear': TheYear,
+                'TheISOYear': TheISOYear,
+                'TheFirstOfYear': TheFirstOfYear,
+                'TheLastOfYear': TheLastOfYear,
+                'IsLeapYear': IsLeapYear,
+                'Has53Weeks': Has53Weeks,
+                'Has53ISOWeeks': Has53ISOWeeks,
+                'MMYYYY': MMYYYY,
+                'Style101': Style101,
+                'Style103': Style103,
+                'Style112': Style112,
+                'Style120': Style120
+            }
+        )
+        current_date = current_date + td(days=1)
+    return row_array

--- a/src/klaviyo_data/vars.py
+++ b/src/klaviyo_data/vars.py
@@ -402,3 +402,49 @@ class TableBuilder:
                      Column('id', NVARCHAR(length=255),
                             primary_key=True, nullable=False),
                      Column('name', NVARCHAR(length=255)))
+
+
+class DateDimension:
+    create_table = """
+        CREATE TABLE dbo.DateDimension (
+        TheDate DATE NULL
+        ,TheDay INT NULL
+        ,TheDaySuffix CHAR(2) NULL
+        ,TheDayName NVARCHAR(30) NULL
+        ,TheDayOfWeek INT NULL
+        ,TheDayOfWeekInMonth TINYINT NULL
+        ,TheDayOfYear INT NULL
+        ,IsWeekend INT NOT NULL
+        ,TheWeek INT NULL
+        ,TheISOweek INT NULL
+        ,TheFirstOfWeek DATE NULL
+        ,TheLastOfWeek DATE NULL
+        ,TheWeekOfMonth TINYINT NULL
+        ,TheMonth INT NULL
+        ,TheMonthName NVARCHAR(30) NULL
+        ,TheFirstOfMonth DATE NULL
+        ,TheLastOfMonth DATE NULL
+        ,TheFirstOfNextMonth DATE NULL
+        ,TheLastOfNextMonth DATE NULL
+        ,TheQuarter INT NULL
+        ,TheFirstOfQuarter DATE NULL
+        ,TheLastOfQuarter DATE NULL
+        ,TheYear INT NULL
+        ,TheISOYear INT NULL
+        ,TheFirstOfYear DATE NULL
+        ,TheLastOfYear DATE NULL
+        ,IsLeapYear BIT NULL
+        ,Has53Weeks INT NOT NULL
+        ,Has53ISOWeeks INT NOT NULL
+        ,MMYYYY CHAR(6) NULL
+        ,Style101 CHAR(10) NULL
+        ,Style103 CHAR(10) NULL
+        ,Style112 CHAR(8) NULL
+        ,Style120 CHAR(10) NULL
+        ) ON [PRIMARY]
+    """
+    create_index = """
+        CREATE UNIQUE CLUSTERED INDEX PK_DateDimension
+            ON dbo.DateDimension (TheDate)
+            ON [PRIMARY]
+    """


### PR DESCRIPTION
Add Date Dimension table function to `DBBuilder` class, CLI, & sql script
Fix pulling metrics for campaigns that were sent later in day and klaviyo broke into two days of sending